### PR TITLE
fix : signup 과 login 비밀번호 유효성검사 상이한 기준 수정

### DIFF
--- a/Terminal-iOS/Login/IntroInteractor.swift
+++ b/Terminal-iOS/Login/IntroInteractor.swift
@@ -62,7 +62,7 @@ final class IntroInteractor: IntroInteractorProtocol {
     // MARK: 로그인 패스워드 체크
     
     func checkedPasswordValid(input: String) {
-        if input.count >= 8 && input.count <= 20 {
+        if input.count >= 6 && input.count <= 20 {
             presenter?.passwordValidInfo(result: true)
             IntroLocalDataManager.shared.password = input
         } else {


### PR DESCRIPTION
## What does this PR do?
- 회원가입 비밀번호 유효성 8~20 -> 6~20
