### PR TITLE
fix: pod error solve

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ target 'Terminal-iOS' do
 
   pod 'SwiftLint'
   pod 'Then'
-  pod 'NMapsMap'
+  pod 'NMapsMap', '3.10.0'
   pod 'Alamofire'
   pod 'SwiftyJSON'
   pod 'Kingfisher'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -75,7 +75,7 @@ PODS:
     - nanopb/encode (= 2.30907.0)
   - nanopb/decode (2.30907.0)
   - nanopb/encode (2.30907.0)
-  - NMapsMap (3.11.0)
+  - NMapsMap (3.10.0)
   - PromisesObjC (1.2.12)
   - Socket.IO-Client-Swift (15.2.0):
     - Starscream (~> 3.1)
@@ -91,7 +91,7 @@ DEPENDENCIES:
   - Firebase/Crashlytics
   - Kingfisher
   - lottie-ios
-  - NMapsMap
+  - NMapsMap (= 3.10.0)
   - Socket.IO-Client-Swift (~> 15.2.0)
   - SwiftKeychainWrapper
   - SwiftLint
@@ -136,7 +136,7 @@ SPEC CHECKSUMS:
   Kingfisher: e71c6fac2aebb1262888cabc2cb13d313362a48f
   lottie-ios: 106e92eaf11fbed0a76590b4cdb9b5ec26123ff7
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
-  NMapsMap: e6dbea85c2c195c7532deb637a5e90fd70f94fed
+  NMapsMap: 17caab4af9a3fc5c25b79858de18bdeab1eaff87
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Socket.IO-Client-Swift: 1e3e3a1f09f3312a167f0d781eb2f383d477357c
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
@@ -145,6 +145,6 @@ SPEC CHECKSUMS:
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   Then: acfe0be7e98221c6204e12f8161459606d5d822d
 
-PODFILE CHECKSUM: c1b16e1def87fa47a589b0b1f1d217bd478fb29d
+PODFILE CHECKSUM: 06b391bade41020a94df8741ec114b8a1c85e92f
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.0


### PR DESCRIPTION
## What does this PR do?
현재 NMapsMap의 최신버전 3.11.0 demo을 설치하면 

```
/Users/susemi99/.../Pods/NMapsMap/framework/NMapsMap.framework/NMapsMap, building for iOS Simulator-x86_64 but attempting to link with file built for unknown-unsupported file format ( 0x76 0x65 0x72 0x73 0x69 0x6F 0x6E 0x20 0x68 0x74 0x74 0x70 0x73 0x3A 0x2F 0x2F )
```

오류가 뜨는 것을 확인할 수 있습니다. 그래서 3.10.0 버전으로 명시해주면 빌드가 잘 되는 것을 확인할 수 있습니다.

또한 readme.md에 git-lfs 관련한 글도 추가하면 어떨까요??

프로젝트 봤는데 너무 잘해놓으셨어요👍
배우고자 들어왔습니다!


